### PR TITLE
make it work

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,16 @@ Open the **config.py** file and modify the following fields with your credential
     sudo docker push DOCKER_HUBPATH
     instead of build use DOCKER_HUB_PATH
     if still error use sude docker-compose run --rm app bash and run migration command
+
+# Run app using docker-compose
+
+   `sudo docker-compose up`
+    Note:- If you encounter any issue after this please run below command
+    ```
+        1. `sudo docker-compose stop`
+        2. `sudo docker-compose rm -v`
+        3. `sudo docker-compose up`
+    ```
+
+    For daemon mode please run with -d for ex. `sudo docker-compose up -d`
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,22 +1,38 @@
-version: "3"
+version: "2.1"
 services:
   app:
     build: .
-    links:
-      - db
+    restart: unless-stopped
+    networks:
+      - flask-backend-tier
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
       - "5000:5000"
+    volumes:
+      - .:/code
     environment:
-      SQLALCHEMY_DATABASE_URI: "mysql://admin:root@db/db_chicago_dish"
+      SQLALCHEMY_DATABASE_URI: "mysql://admin:12345678@db/chicago_dish"
   db:
     image: mysql:5.7
+    restart: unless-stopped
     ports:
       - "32000:3306"
+    networks:
+      - flask-backend-tier
+    healthcheck:
+        test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+        timeout: 20s
+        retries: 10
     environment:
-      MYSQL_ROOT_PASSWORD: 12345678
-      MYSQL_USER: admin
-      MYSQL_PASSWORD: 12345678
-      MYSQL_DATABASE: db_chicago_dish
+      - MYSQL_DATABASE=chicago_dish
+      - MYSQL_USER=admin
+      - MYSQL_PASSWORD=12345678
+      - MYSQL_ROOT_PASSWORD=12345678
     volumes:
       - ./db:/docker-entrypoint-initdb.d/:ro
 
+networks:
+  flask-backend-tier:
+    driver: bridge

--- a/docker_entry.sh
+++ b/docker_entry.sh
@@ -4,8 +4,10 @@ set -e
 echo "Database URL ${SQLALCHEMY_DATABASE_URI}"
 
 echo "RUNNING MIGRATIONS"
-python3 db-migrate.py db migrate
-python3 db-migrate.py db upgrade
+
+python3 db-migrate.py db stamp head # To set the revision in the database to the head, without performing any migrations. You can change head to the required change you want.
+python3 db-migrate.py db migrate # To detect automatically all the changes.
+python3 db-migrate.py db upgrade # To apply all the changes.
 
 echo "RUNNING SERVER"
 


### PR DESCRIPTION
Logs:-

```
[CORP\ankitkhadria1@a-1nosayjlhjkpd DishWebsite]$ sudo docker-compose up
Creating dishwebsite_db_1 ... done
Creating dishwebsite_app_1 ... done
Attaching to dishwebsite_db_1, dishwebsite_app_1
db_1   | 2020-04-13 17:59:14+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.29-1debian10 started.
db_1   | 2020-04-13 17:59:14+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
db_1   | 2020-04-13 17:59:14+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 5.7.29-1debian10 started.
db_1   | 2020-04-13 17:59:14+00:00 [Note] [Entrypoint]: Initializing database files
db_1   | 2020-04-13T17:59:14.981810Z 0 [Warning] Changed limits: max_open_files: 1024 (requested 5000)
db_1   | 2020-04-13T17:59:14.981855Z 0 [Warning] Changed limits: table_open_cache: 431 (requested 2000)
db_1   | 2020-04-13T17:59:14.981992Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
db_1   | 2020-04-13T17:59:16.064198Z 0 [Warning] InnoDB: New log files created, LSN=45790
db_1   | 2020-04-13T17:59:16.335499Z 0 [Warning] InnoDB: Creating foreign key constraint system tables.
db_1   | 2020-04-13T17:59:16.358598Z 0 [Warning] No existing UUID has been found, so we assume that this is the first time that this server has been started. Generating a new UUID: 7da02916-7db0-11ea-8a5b-0242ac140002.
db_1   | 2020-04-13T17:59:16.359983Z 0 [Warning] Gtid table is not ready to be used. Table 'mysql.gtid_executed' cannot be opened.
db_1   | 2020-04-13T17:59:17.215911Z 0 [Warning] CA certificate ca.pem is self signed.
db_1   | 2020-04-13T17:59:17.829713Z 1 [Warning] root@localhost is created with an empty password ! Please consider switching off the --initialize-insecure option.
db_1   | 2020-04-13 17:59:20+00:00 [Note] [Entrypoint]: Database files initialized
db_1   | 2020-04-13 17:59:20+00:00 [Note] [Entrypoint]: Starting temporary server
db_1   | 2020-04-13 17:59:20+00:00 [Note] [Entrypoint]: Waiting for server startup
db_1   | 2020-04-13T17:59:20.378490Z 0 [Warning] Changed limits: max_open_files: 1024 (requested 5000)
db_1   | 2020-04-13T17:59:20.378542Z 0 [Warning] Changed limits: table_open_cache: 431 (requested 2000)
db_1   | 2020-04-13T17:59:20.557826Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
db_1   | 2020-04-13T17:59:20.559825Z 0 [Note] mysqld (mysqld 5.7.29) starting as process 76 ...
db_1   | 2020-04-13T17:59:20.564057Z 0 [Note] InnoDB: PUNCH HOLE support available
db_1   | 2020-04-13T17:59:20.564081Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
db_1   | 2020-04-13T17:59:20.564088Z 0 [Note] InnoDB: Uses event mutexes
db_1   | 2020-04-13T17:59:20.564094Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
db_1   | 2020-04-13T17:59:20.564099Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
db_1   | 2020-04-13T17:59:20.564105Z 0 [Note] InnoDB: Using Linux native AIO
db_1   | 2020-04-13T17:59:20.564418Z 0 [Note] InnoDB: Number of pools: 1
db_1   | 2020-04-13T17:59:20.564577Z 0 [Note] InnoDB: Using CPU crc32 instructions
db_1   | 2020-04-13T17:59:20.566422Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
db_1   | 2020-04-13T17:59:20.575813Z 0 [Note] InnoDB: Completed initialization of buffer pool
db_1   | 2020-04-13T17:59:20.578572Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
db_1   | 2020-04-13T17:59:20.590379Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
db_1   | 2020-04-13T17:59:20.598188Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
db_1   | 2020-04-13T17:59:20.598250Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
db_1   | 2020-04-13T17:59:20.628196Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
db_1   | 2020-04-13T17:59:20.629506Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
db_1   | 2020-04-13T17:59:20.629531Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
db_1   | 2020-04-13T17:59:20.630164Z 0 [Note] InnoDB: Waiting for purge to start
db_1   | 2020-04-13T17:59:20.680443Z 0 [Note] InnoDB: 5.7.29 started; log sequence number 2630167
db_1   | 2020-04-13T17:59:20.680819Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
db_1   | 2020-04-13T17:59:20.681098Z 0 [Note] Plugin 'FEDERATED' is disabled.
db_1   | 2020-04-13T17:59:20.683359Z 0 [Note] InnoDB: Buffer pool(s) load completed at 200413 17:59:20
db_1   | 2020-04-13T17:59:20.688322Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
db_1   | 2020-04-13T17:59:20.688370Z 0 [Note] Skipping generation of SSL certificates as certificate files are present in data directory.
db_1   | 2020-04-13T17:59:20.688954Z 0 [Warning] CA certificate ca.pem is self signed.
db_1   | 2020-04-13T17:59:20.689002Z 0 [Note] Skipping generation of RSA key pair as key files are present in data directory.
db_1   | 2020-04-13T17:59:20.693719Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
db_1   | 2020-04-13T17:59:20.703177Z 0 [Note] Event Scheduler: Loaded 0 events
db_1   | 2020-04-13T17:59:20.703505Z 0 [Note] mysqld: ready for connections.
db_1   | Version: '5.7.29'  socket: '/var/run/mysqld/mysqld.sock'  port: 0  MySQL Community Server (GPL)
db_1   | 2020-04-13 17:59:21+00:00 [Note] [Entrypoint]: Temporary server started.
db_1   | Warning: Unable to load '/usr/share/zoneinfo/iso3166.tab' as time zone. Skipping it.
db_1   | Warning: Unable to load '/usr/share/zoneinfo/leap-seconds.list' as time zone. Skipping it.
db_1   | Warning: Unable to load '/usr/share/zoneinfo/zone.tab' as time zone. Skipping it.
db_1   | Warning: Unable to load '/usr/share/zoneinfo/zone1970.tab' as time zone. Skipping it.
db_1   | 2020-04-13 17:59:23+00:00 [Note] [Entrypoint]: Creating database chicago_dish
db_1   | 2020-04-13 17:59:23+00:00 [Note] [Entrypoint]: Creating user admin
db_1   | 2020-04-13 17:59:23+00:00 [Note] [Entrypoint]: Giving user admin access to schema chicago_dish
db_1   | 
app_1  | Database URL mysql://admin:12345678@db/chicago_dish
app_1  | RUNNING MIGRATIONS
db_1   | 2020-04-13 17:59:23+00:00 [Note] [Entrypoint]: Stopping temporary server
db_1   | 2020-04-13T17:59:23.825905Z 0 [Note] Giving 0 client threads a chance to die gracefully
db_1   | 2020-04-13T17:59:23.825949Z 0 [Note] Shutting down slave threads
db_1   | 2020-04-13T17:59:23.825957Z 0 [Note] Forcefully disconnecting 0 remaining clients
db_1   | 2020-04-13T17:59:23.825964Z 0 [Note] Event Scheduler: Purging the queue. 0 events
db_1   | 2020-04-13T17:59:23.826056Z 0 [Note] Binlog end
db_1   | 2020-04-13T17:59:23.826498Z 0 [Note] Shutting down plugin 'ngram'
db_1   | 2020-04-13T17:59:23.826517Z 0 [Note] Shutting down plugin 'partition'
db_1   | 2020-04-13T17:59:23.826522Z 0 [Note] Shutting down plugin 'BLACKHOLE'
db_1   | 2020-04-13T17:59:23.826528Z 0 [Note] Shutting down plugin 'ARCHIVE'
db_1   | 2020-04-13T17:59:23.826560Z 0 [Note] Shutting down plugin 'PERFORMANCE_SCHEMA'
db_1   | 2020-04-13T17:59:23.826623Z 0 [Note] Shutting down plugin 'MRG_MYISAM'
db_1   | 2020-04-13T17:59:23.826649Z 0 [Note] Shutting down plugin 'MyISAM'
db_1   | 2020-04-13T17:59:23.826771Z 0 [Note] Shutting down plugin 'INNODB_SYS_VIRTUAL'
db_1   | 2020-04-13T17:59:23.826785Z 0 [Note] Shutting down plugin 'INNODB_SYS_DATAFILES'
db_1   | 2020-04-13T17:59:23.826790Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLESPACES'
db_1   | 2020-04-13T17:59:23.826794Z 0 [Note] Shutting down plugin 'INNODB_SYS_FOREIGN_COLS'
db_1   | 2020-04-13T17:59:23.826798Z 0 [Note] Shutting down plugin 'INNODB_SYS_FOREIGN'
db_1   | 2020-04-13T17:59:23.826896Z 0 [Note] Shutting down plugin 'INNODB_SYS_FIELDS'
db_1   | 2020-04-13T17:59:23.826911Z 0 [Note] Shutting down plugin 'INNODB_SYS_COLUMNS'
db_1   | 2020-04-13T17:59:23.826915Z 0 [Note] Shutting down plugin 'INNODB_SYS_INDEXES'
db_1   | 2020-04-13T17:59:23.826919Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLESTATS'
db_1   | 2020-04-13T17:59:23.826924Z 0 [Note] Shutting down plugin 'INNODB_SYS_TABLES'
db_1   | 2020-04-13T17:59:23.826928Z 0 [Note] Shutting down plugin 'INNODB_FT_INDEX_TABLE'
db_1   | 2020-04-13T17:59:23.826932Z 0 [Note] Shutting down plugin 'INNODB_FT_INDEX_CACHE'
db_1   | 2020-04-13T17:59:23.827048Z 0 [Note] Shutting down plugin 'INNODB_FT_CONFIG'
db_1   | 2020-04-13T17:59:23.827052Z 0 [Note] Shutting down plugin 'INNODB_FT_BEING_DELETED'
db_1   | 2020-04-13T17:59:23.827057Z 0 [Note] Shutting down plugin 'INNODB_FT_DELETED'
db_1   | 2020-04-13T17:59:23.827060Z 0 [Note] Shutting down plugin 'INNODB_FT_DEFAULT_STOPWORD'
db_1   | 2020-04-13T17:59:23.827152Z 0 [Note] Shutting down plugin 'INNODB_METRICS'
db_1   | 2020-04-13T17:59:23.827164Z 0 [Note] Shutting down plugin 'INNODB_TEMP_TABLE_INFO'
db_1   | 2020-04-13T17:59:23.827169Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_POOL_STATS'
db_1   | 2020-04-13T17:59:23.827173Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_PAGE_LRU'
db_1   | 2020-04-13T17:59:23.827177Z 0 [Note] Shutting down plugin 'INNODB_BUFFER_PAGE'
db_1   | 2020-04-13T17:59:23.827182Z 0 [Note] Shutting down plugin 'INNODB_CMP_PER_INDEX_RESET'
db_1   | 2020-04-13T17:59:23.827353Z 0 [Note] Shutting down plugin 'INNODB_CMP_PER_INDEX'
db_1   | 2020-04-13T17:59:23.827472Z 0 [Note] Shutting down plugin 'INNODB_CMPMEM_RESET'
db_1   | 2020-04-13T17:59:23.827485Z 0 [Note] Shutting down plugin 'INNODB_CMPMEM'
db_1   | 2020-04-13T17:59:23.827491Z 0 [Note] Shutting down plugin 'INNODB_CMP_RESET'
db_1   | 2020-04-13T17:59:23.827494Z 0 [Note] Shutting down plugin 'INNODB_CMP'
db_1   | 2020-04-13T17:59:23.827499Z 0 [Note] Shutting down plugin 'INNODB_LOCK_WAITS'
db_1   | 2020-04-13T17:59:23.827503Z 0 [Note] Shutting down plugin 'INNODB_LOCKS'
db_1   | 2020-04-13T17:59:23.827506Z 0 [Note] Shutting down plugin 'INNODB_TRX'
db_1   | 2020-04-13T17:59:23.827613Z 0 [Note] Shutting down plugin 'InnoDB'
db_1   | 2020-04-13T17:59:23.827766Z 0 [Note] InnoDB: FTS optimize thread exiting.
db_1   | 2020-04-13T17:59:23.827950Z 0 [Note] InnoDB: Starting shutdown...
db_1   | 2020-04-13T17:59:23.928347Z 0 [Note] InnoDB: Dumping buffer pool(s) to /var/lib/mysql/ib_buffer_pool
db_1   | 2020-04-13T17:59:23.929614Z 0 [Note] InnoDB: Buffer pool(s) dump completed at 200413 17:59:23
db_1   | 2020-04-13T17:59:25.540794Z 0 [Note] InnoDB: Shutdown completed; log sequence number 12480758
db_1   | 2020-04-13T17:59:25.543309Z 0 [Note] InnoDB: Removed temporary tablespace data file: "ibtmp1"
db_1   | 2020-04-13T17:59:25.543366Z 0 [Note] Shutting down plugin 'MEMORY'
db_1   | 2020-04-13T17:59:25.543385Z 0 [Note] Shutting down plugin 'CSV'
db_1   | 2020-04-13T17:59:25.543397Z 0 [Note] Shutting down plugin 'sha256_password'
db_1   | 2020-04-13T17:59:25.543407Z 0 [Note] Shutting down plugin 'mysql_native_password'
db_1   | 2020-04-13T17:59:25.544119Z 0 [Note] Shutting down plugin 'binlog'
db_1   | 2020-04-13T17:59:25.544450Z 0 [Note] mysqld: Shutdown complete
db_1   | 
db_1   | 2020-04-13 17:59:25+00:00 [Note] [Entrypoint]: Temporary server stopped
db_1   | 
db_1   | 2020-04-13 17:59:25+00:00 [Note] [Entrypoint]: MySQL init process done. Ready for start up.
db_1   | 
db_1   | 2020-04-13T17:59:25.853926Z 0 [Warning] Changed limits: max_open_files: 1024 (requested 5000)
db_1   | 2020-04-13T17:59:25.853979Z 0 [Warning] Changed limits: table_open_cache: 431 (requested 2000)
db_1   | 2020-04-13T17:59:26.024440Z 0 [Warning] TIMESTAMP with implicit DEFAULT value is deprecated. Please use --explicit_defaults_for_timestamp server option (see documentation for more details).
db_1   | 2020-04-13T17:59:26.027137Z 0 [Note] mysqld (mysqld 5.7.29) starting as process 1 ...
db_1   | 2020-04-13T17:59:26.032909Z 0 [Note] InnoDB: PUNCH HOLE support available
db_1   | 2020-04-13T17:59:26.032933Z 0 [Note] InnoDB: Mutexes and rw_locks use GCC atomic builtins
db_1   | 2020-04-13T17:59:26.032939Z 0 [Note] InnoDB: Uses event mutexes
db_1   | 2020-04-13T17:59:26.032945Z 0 [Note] InnoDB: GCC builtin __atomic_thread_fence() is used for memory barrier
db_1   | 2020-04-13T17:59:26.033061Z 0 [Note] InnoDB: Compressed tables use zlib 1.2.11
db_1   | 2020-04-13T17:59:26.033077Z 0 [Note] InnoDB: Using Linux native AIO
db_1   | 2020-04-13T17:59:26.033401Z 0 [Note] InnoDB: Number of pools: 1
db_1   | 2020-04-13T17:59:26.033579Z 0 [Note] InnoDB: Using CPU crc32 instructions
db_1   | 2020-04-13T17:59:26.036397Z 0 [Note] InnoDB: Initializing buffer pool, total size = 128M, instances = 1, chunk size = 128M
db_1   | 2020-04-13T17:59:26.045538Z 0 [Note] InnoDB: Completed initialization of buffer pool
db_1   | 2020-04-13T17:59:26.048341Z 0 [Note] InnoDB: If the mysqld execution user is authorized, page cleaner thread priority can be changed. See the man page of setpriority().
db_1   | 2020-04-13T17:59:26.061183Z 0 [Note] InnoDB: Highest supported file format is Barracuda.
db_1   | 2020-04-13T17:59:26.079298Z 0 [Note] InnoDB: Creating shared tablespace for temporary tables
db_1   | 2020-04-13T17:59:26.079456Z 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
db_1   | 2020-04-13T17:59:26.102892Z 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
db_1   | 2020-04-13T17:59:26.103758Z 0 [Note] InnoDB: 96 redo rollback segment(s) found. 96 redo rollback segment(s) are active.
db_1   | 2020-04-13T17:59:26.103776Z 0 [Note] InnoDB: 32 non-redo rollback segment(s) are active.
db_1   | 2020-04-13T17:59:26.104402Z 0 [Note] InnoDB: 5.7.29 started; log sequence number 12480758
db_1   | 2020-04-13T17:59:26.104714Z 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
db_1   | 2020-04-13T17:59:26.105044Z 0 [Note] Plugin 'FEDERATED' is disabled.
db_1   | 2020-04-13T17:59:26.113546Z 0 [Note] InnoDB: Buffer pool(s) load completed at 200413 17:59:26
db_1   | 2020-04-13T17:59:26.118637Z 0 [Note] Found ca.pem, server-cert.pem and server-key.pem in data directory. Trying to enable SSL support using them.
db_1   | 2020-04-13T17:59:26.118764Z 0 [Note] Skipping generation of SSL certificates as certificate files are present in data directory.
db_1   | 2020-04-13T17:59:26.119354Z 0 [Warning] CA certificate ca.pem is self signed.
db_1   | 2020-04-13T17:59:26.119404Z 0 [Note] Skipping generation of RSA key pair as key files are present in data directory.
db_1   | 2020-04-13T17:59:26.120617Z 0 [Note] Server hostname (bind-address): '*'; port: 3306
db_1   | 2020-04-13T17:59:26.120660Z 0 [Note] IPv6 is available.
db_1   | 2020-04-13T17:59:26.121116Z 0 [Note]   - '::' resolves to '::';
db_1   | 2020-04-13T17:59:26.121154Z 0 [Note] Server socket created on IP: '::'.
db_1   | 2020-04-13T17:59:26.123639Z 0 [Warning] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
db_1   | 2020-04-13T17:59:26.132671Z 0 [Note] Event Scheduler: Loaded 0 events
db_1   | 2020-04-13T17:59:26.132971Z 0 [Note] mysqld: ready for connections.
db_1   | Version: '5.7.29'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server (GPL)
db_1   | 2020-04-13T17:59:45.079617Z 2 [Note] Access denied for user 'root'@'localhost' (using password: NO)
app_1  | /env/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
app_1  |   'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
app_1  | 2020-04-13 17:59:47,671 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'sql_mode'
app_1  | 2020-04-13 17:59:47,671 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,676 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'lower_case_table_names'
app_1  | 2020-04-13 17:59:47,676 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,678 INFO sqlalchemy.engine.base.Engine SELECT DATABASE()
app_1  | 2020-04-13 17:59:47,678 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,679 INFO sqlalchemy.engine.base.Engine show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
app_1  | 2020-04-13 17:59:47,679 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,681 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:47,681 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,688 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:47,688 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,691 INFO sqlalchemy.engine.base.Engine SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
app_1  | 2020-04-13 17:59:47,691 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,693 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAccount`
app_1  | 2020-04-13 17:59:47,693 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,694 INFO sqlalchemy.engine.base.Engine ROLLBACK
app_1  | 2020-04-13 17:59:47,694 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAppointments`
app_1  | 2020-04-13 17:59:47,695 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,695 INFO sqlalchemy.engine.base.Engine ROLLBACK
app_1  | 2020-04-13 17:59:47,700 INFO sqlalchemy.engine.base.Engine 
app_1  | CREATE TABLE `UserAccount` (
app_1  | 	id INTEGER NOT NULL AUTO_INCREMENT, 
app_1  | 	name VARCHAR(25) NOT NULL, 
app_1  | 	email VARCHAR(80) NOT NULL, 
app_1  | 	password VARCHAR(200) NOT NULL, 
app_1  | 	created_on DATETIME, 
app_1  | 	PRIMARY KEY (id), 
app_1  | 	UNIQUE (email)
app_1  | )
app_1  | 
app_1  | 
app_1  | 2020-04-13 17:59:47,700 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,714 INFO sqlalchemy.engine.base.Engine COMMIT
app_1  | 2020-04-13 17:59:47,717 INFO sqlalchemy.engine.base.Engine 
app_1  | CREATE TABLE `UserAppointments` (
app_1  | 	id INTEGER NOT NULL AUTO_INCREMENT, 
app_1  | 	`UserAccount_id` INTEGER, 
app_1  | 	visitor_name VARCHAR(20), 
app_1  | 	visitor_email VARCHAR(80), 
app_1  | 	visitor_phone_number VARCHAR(20), 
app_1  | 	address_line_1 VARCHAR(50) NOT NULL, 
app_1  | 	address_line_2 VARCHAR(50), 
app_1  | 	city VARCHAR(20) NOT NULL, 
app_1  | 	state VARCHAR(20) NOT NULL, 
app_1  | 	zipcode VARCHAR(20) NOT NULL, 
app_1  | 	booking_time DATETIME NOT NULL, 
app_1  | 	cus_id VARCHAR(50), 
app_1  | 	paid BOOL, 
app_1  | 	luxury BOOL, 
app_1  | 	dishes INTEGER, 
app_1  | 	price FLOAT, 
app_1  | 	created_on DATETIME, 
app_1  | 	updated_on DATETIME, 
app_1  | 	PRIMARY KEY (id), 
app_1  | 	FOREIGN KEY(`UserAccount_id`) REFERENCES `UserAccount` (id), 
app_1  | 	UNIQUE (cus_id), 
app_1  | 	CHECK (paid IN (0, 1)), 
app_1  | 	CHECK (luxury IN (0, 1))
app_1  | )
app_1  | 
app_1  | 
app_1  | 2020-04-13 17:59:47,718 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:47,732 INFO sqlalchemy.engine.base.Engine COMMIT
app_1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
app_1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
app_1  | INFO  [alembic.runtime.migration] Running stamp_revision  -> d32096924d03
app_1  | /env/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
app_1  |   'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
app_1  | 2020-04-13 17:59:48,665 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'sql_mode'
app_1  | 2020-04-13 17:59:48,666 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,670 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'lower_case_table_names'
app_1  | 2020-04-13 17:59:48,670 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,672 INFO sqlalchemy.engine.base.Engine SELECT DATABASE()
app_1  | 2020-04-13 17:59:48,672 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,672 INFO sqlalchemy.engine.base.Engine show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
app_1  | 2020-04-13 17:59:48,672 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,674 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:48,674 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,675 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:48,675 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,676 INFO sqlalchemy.engine.base.Engine SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
app_1  | 2020-04-13 17:59:48,676 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,680 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAccount`
app_1  | 2020-04-13 17:59:48,680 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:48,681 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAppointments`
app_1  | 2020-04-13 17:59:48,682 INFO sqlalchemy.engine.base.Engine ()
app_1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
app_1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
app_1  | INFO  [alembic.env] No changes in schema detected.
app_1  | /env/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
app_1  |   'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
app_1  | 2020-04-13 17:59:49,919 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'sql_mode'
app_1  | 2020-04-13 17:59:49,919 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,921 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'lower_case_table_names'
app_1  | 2020-04-13 17:59:49,922 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,924 INFO sqlalchemy.engine.base.Engine SELECT DATABASE()
app_1  | 2020-04-13 17:59:49,924 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,925 INFO sqlalchemy.engine.base.Engine show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
app_1  | 2020-04-13 17:59:49,925 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,927 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:49,927 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,928 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:49,928 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,929 INFO sqlalchemy.engine.base.Engine SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
app_1  | 2020-04-13 17:59:49,929 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,935 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAccount`
app_1  | 2020-04-13 17:59:49,935 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:49,937 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAppointments`
app_1  | 2020-04-13 17:59:49,937 INFO sqlalchemy.engine.base.Engine ()
app_1  | INFO  [alembic.runtime.migration] Context impl MySQLImpl.
app_1  | INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
app_1  | RUNNING SERVER
app_1  | /env/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
app_1  |   'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
app_1  | 2020-04-13 17:59:50,791 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'sql_mode'
app_1  | 2020-04-13 17:59:50,791 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,793 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'lower_case_table_names'
app_1  | 2020-04-13 17:59:50,794 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,795 INFO sqlalchemy.engine.base.Engine SELECT DATABASE()
app_1  | 2020-04-13 17:59:50,796 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,797 INFO sqlalchemy.engine.base.Engine show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
app_1  | 2020-04-13 17:59:50,797 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,798 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:50,798 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,800 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:50,800 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,801 INFO sqlalchemy.engine.base.Engine SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
app_1  | 2020-04-13 17:59:50,801 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,809 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAccount`
app_1  | 2020-04-13 17:59:50,809 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:50,810 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAppointments`
app_1  | 2020-04-13 17:59:50,810 INFO sqlalchemy.engine.base.Engine ()
app_1  |  * Serving Flask app "chicago_dish_removal" (lazy loading)
app_1  |  * Environment: production
app_1  |    WARNING: This is a development server. Do not use it in a production deployment.
app_1  |    Use a production WSGI server instead.
app_1  |  * Debug mode: on
app_1  |  * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
app_1  |  * Restarting with stat
app_1  | /env/lib/python3.6/site-packages/flask_sqlalchemy/__init__.py:835: FSADeprecationWarning: SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and will be disabled by default in the future.  Set it to True or False to suppress this warning.
app_1  |   'SQLALCHEMY_TRACK_MODIFICATIONS adds significant overhead and '
app_1  | 2020-04-13 17:59:51,527 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'sql_mode'
app_1  | 2020-04-13 17:59:51,527 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,530 INFO sqlalchemy.engine.base.Engine SHOW VARIABLES LIKE 'lower_case_table_names'
app_1  | 2020-04-13 17:59:51,530 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,532 INFO sqlalchemy.engine.base.Engine SELECT DATABASE()
app_1  | 2020-04-13 17:59:51,532 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,533 INFO sqlalchemy.engine.base.Engine show collation where `Charset` = 'utf8mb4' and `Collation` = 'utf8mb4_bin'
app_1  | 2020-04-13 17:59:51,533 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,535 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:51,535 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,537 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS CHAR(60)) AS anon_1
app_1  | 2020-04-13 17:59:51,537 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,538 INFO sqlalchemy.engine.base.Engine SELECT CAST('test collated returns' AS CHAR CHARACTER SET utf8mb4) COLLATE utf8mb4_bin AS anon_1
app_1  | 2020-04-13 17:59:51,538 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,542 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAccount`
app_1  | 2020-04-13 17:59:51,542 INFO sqlalchemy.engine.base.Engine ()
app_1  | 2020-04-13 17:59:51,544 INFO sqlalchemy.engine.base.Engine DESCRIBE `UserAppointments`
app_1  | 2020-04-13 17:59:51,544 INFO sqlalchemy.engine.base.Engine ()
app_1  |  * Debugger is active!
app_1  |  * Debugger PIN: 210-215-869
```